### PR TITLE
append slash for Daseen endpoint

### DIFF
--- a/edc-edp-extension/connector/src/main/java/io/nexyo/edp/extensions/services/DaseenService.java
+++ b/edc-edp-extension/connector/src/main/java/io/nexyo/edp/extensions/services/DaseenService.java
@@ -64,7 +64,7 @@ public class DaseenService {
     public DaseenCreateResourceResponseDto createDaseenResource(String assetId) {
         this.logger.info(String.format("Creating Daseen Resource for Asset: %s...", assetId));
 
-        var apiResponse = httpClient.target(String.format("%s/connector/edp", this.daseenBaseUrl))
+        var apiResponse = httpClient.target(String.format("%s/connector/edp/", this.daseenBaseUrl))
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.entity(MockUtils.createRequestBody(assetId), MediaType.APPLICATION_JSON));
 


### PR DESCRIPTION
Only `/connector/edp/` is accepted. `/connector/edp` throws 500 Error.